### PR TITLE
Setup Lint and Push Action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,30 @@
+name: golangci-lint
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    paths:
+      - '**.go'
+      - '**/go.mod'
+      - '**/go.sum'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.23.0
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.0

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,110 @@
+#
+name: Create and publish a Release Image
+
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
+on:
+  release:
+    types: [released]
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+      #
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Check Latest Tag
+        id: latest_tag
+        run: |
+          LATEST_TAG=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)
+          if [[ "$LATEST_TAG" == "${{ github.ref_name }}" ]]; then
+            echo "latest_tag=true" >> $GITHUB_OUTPUT
+          else
+            echo "latest_tag=false" >> $GITHUB_OUTPUT
+          fi
+
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca
+
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker of the standalone Version
+        id: meta-standalone
+        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=${{ steps.latest_tag.outputs.latest_tag }}
+          tags: |
+            type=semver,pattern={{major}}
+            type=semver,pattern={{version}}-standalone
+            type=semver,pattern={{major}}.{{minor}}-standalone
+            type=semver,pattern={{major}}-standalone
+      - name: Build and push Docker Standalone image
+        id: push-standalone
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          file: ${{context}}/Dockerfile-standalone
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta-standalone.outputs.tags }}
+          labels: ${{ steps.meta-standalone.outputs.labels }}
+      - name: Generate artifact attestation for GHCR.io
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push-standalone.outputs.digest }}
+          push-to-registry: true
+
+      - name: Extract metadata (tags, labels) for Docker of the Bundled Version
+        id: meta-bundled
+        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}}-bundled
+            type=semver,pattern={{major}}.{{minor}}-bundled
+            type=semver,pattern={{major}}-bundled
+      - name: Build and push Docker Bundled image
+        id: push-bundled
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          file: ${{context}}/Dockerfile-bundled
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta-bundled.outputs.tags }}
+          labels: ${{ steps.meta-bundled.outputs.labels }}
+      - name: Generate artifact attestation for GHCR.io
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push-bundled.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
This pull request introduces two new GitHub Actions workflows to the repository: one for running Go linting and another for creating and publishing a Docker image upon release. These workflows will automate code quality checks and streamline the release process.

New GitHub Actions workflows:

* [`.github/workflows/golangci-lint.yml`](diffhunk://#diff-d9a956120ac84289d2650137f64bd8f0893331de05e44cc41899dd984c9e0d48R1-R30): Adds a workflow to run `golangci-lint` on `push` and `pull_request` events for Go files. This ensures that linting is performed on the `main` and `dev` branches, as well as on any pull requests affecting Go files.

* [`.github/workflows/publish-image.yml`](diffhunk://#diff-20a6c39db0bdbf998cfc2078fa28cc6734ee3dd8efd0a7edab29379b6ed95aa8R1-R110): Adds a workflow to create and publish a Docker image when a release is published. This includes steps for checking out the repository, logging into the container registry, setting up QEMU and Docker Buildx, extracting metadata, building and pushing Docker images, and generating artifact attestations.